### PR TITLE
WIP Use sequential ids for files to enforce order

### DIFF
--- a/src/commands/plan.rs
+++ b/src/commands/plan.rs
@@ -23,20 +23,19 @@ impl Plan {
         let timestamp = Utc::now().timestamp();
 
         let filename = format!("{:03}.{}.{}.sql", config.next_id, timestamp, name);
-        let revision_path = config
-            .paths
-            .revisions
-            .join(&filename);
+        let revision_path = config.paths.revisions.join(&filename);
 
-        let cmd = Self { filename, path: revision_path };
+        let cmd = Self {
+            filename,
+            path: revision_path,
+        };
 
         Ok(cmd.create_file()?)
     }
 
     fn create_file(self) -> Result<Self> {
-        fs::File::create(&self.path)?.write_all(
-            TEMPLATE.replace(":filename", &self.filename).as_bytes()
-        )?;
+        fs::File::create(&self.path)?
+            .write_all(TEMPLATE.replace(":filename", &self.filename).as_bytes())?;
 
         Ok(self)
     }

--- a/src/commands/plan.rs
+++ b/src/commands/plan.rs
@@ -22,7 +22,7 @@ impl Plan {
     pub fn new_revision(config: &Config, name: &str) -> Result<Self> {
         let timestamp = Utc::now().timestamp();
 
-        let filename = format!("{}.{}.sql", timestamp, name);
+        let filename = format!("{:03}.{}.{}.sql", config.next_id, timestamp, name);
         let revision_path = config
             .paths
             .revisions

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -56,6 +56,7 @@ impl Review {
     fn annotate(mut self) -> Self {
         for file in self.files.iter() {
             let mut anno = AnnotatedRevision {
+                id: file.id,
                 applied_on: None,
                 checksum: Some(file.checksum.clone()),
                 checksums_match: None,
@@ -80,6 +81,7 @@ impl Review {
             }
 
             let anno = AnnotatedRevision {
+                id: record.id,
                 applied_on: Some(record.applied_on),
                 checksum: None,
                 checksums_match: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,12 +78,17 @@ impl Config {
             table: toml_settings.table,
         };
 
-        let next_id = RevisionFile::all_from_disk(&paths.revisions)?.iter()
+        let next_id = RevisionFile::all_from_disk(&paths.revisions)?
+            .iter()
             .reduce(|rf1, rf2| if rf1.id > rf2.id { rf1 } else { rf2 })
             .map_or(0, |rf| rf.id as i32)
             + 1;
 
-        let config = Self { paths, settings, next_id };
+        let config = Self {
+            paths,
+            settings,
+            next_id,
+        };
 
         Ok(config)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,11 +78,12 @@ impl Config {
             table: toml_settings.table,
         };
 
-        let last_id = RevisionFile::all_from_disk(&paths.revisions)?.iter()
-            .reduce(|a, b| if a.created_at > b.created_at { a } else { b })
-            .map_or(0, |rf| rf.created_at.timestamp());
+        let next_id = RevisionFile::all_from_disk(&paths.revisions)?.iter()
+            .reduce(|rf1, rf2| if rf1.id > rf2.id { rf1 } else { rf2 })
+            .map_or(0, |rf| rf.id as i32)
+            + 1;
 
-        let config = Self { paths, settings, next_id: last_id as i32 + 1 };
+        let config = Self { paths, settings, next_id };
 
         Ok(config)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,13 @@
-use serde::Deserialize;
 use std::{env, fs};
 
-use crate::{paths::ProjectPaths, Error, Result};
+use serde::Deserialize;
+
+use crate::{
+    paths::ProjectPaths,
+    revisions::RevisionFile,
+    Error,
+    Result,
+};
 
 /// Strategy for locating connection details.
 /// Currently only supports whole URL-style string but it could be extended to support
@@ -42,9 +48,11 @@ struct TomlSettings {
     pub table: TableSettings,
 }
 
+#[derive(Debug)]
 pub struct Config {
     pub paths: ProjectPaths,
     pub settings: Settings,
+    pub next_id: i32,
 }
 
 impl Config {
@@ -70,7 +78,13 @@ impl Config {
             table: toml_settings.table,
         };
 
-        Ok(Self { paths, settings })
+        let last_id = RevisionFile::all_from_disk(&paths.revisions)?.iter()
+            .reduce(|a, b| if a.created_at > b.created_at { a } else { b })
+            .map_or(0, |rf| rf.created_at.timestamp());
+
+        let config = Self { paths, settings, next_id: last_id as i32 + 1 };
+
+        Ok(config)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
     RevisionNameInvalid(String),
     RevisionTimestampInvalid(num::ParseIntError, String),
     RevisionTimestampOutOfRange(String),
-    RevisionsFailedReview { changed: usize, missing: usize },
+    RevisionsFailedReview { changed: usize, missing: usize, predate_applied: usize },
     TransactionCommandFound(String),
 }
 
@@ -76,15 +76,19 @@ impl fmt::Display for Error {
                     filename
                 )
             }
-            RevisionsFailedReview { changed, missing } => {
+            RevisionsFailedReview { changed, missing, predate_applied } => {
                 let mut errs = String::new();
 
                 if *changed > 0 {
-                    errs.push_str(&format!("\n\t{} changed since being applied", changed,));
+                    errs.push_str(&format!("\n\t{} changed since being applied", changed));
                 }
 
                 if *missing > 0 {
-                    errs.push_str(&format!("\n\t{} no longer present on disk", missing,));
+                    errs.push_str(&format!("\n\t{} applied no longer present", missing));
+                }
+
+                if *predate_applied > 0 {
+                    errs.push_str(&format!("\n\t{} pending occur before applied revisions", predate_applied));
                 }
 
                 write!(f, "Revisions review failed:{}", errs)

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,7 +84,12 @@ impl fmt::Display for Error {
                     filename
                 )
             }
-            RevisionsFailedReview { changed, duplicate_ids, missing, predate_applied } => {
+            RevisionsFailedReview {
+                changed,
+                duplicate_ids,
+                missing,
+                predate_applied,
+            } => {
                 let mut errs = String::new();
 
                 if *changed > 0 {
@@ -92,7 +97,11 @@ impl fmt::Display for Error {
                 }
 
                 if *duplicate_ids > 0 {
-                    let (verb, id) = if *duplicate_ids > 1 { ("have", "ids") } else { ("has a", "id") };
+                    let (verb, id) = if *duplicate_ids > 1 {
+                        ("have", "ids")
+                    } else {
+                        ("has a", "id")
+                    };
                     errs.push_str(&format!("\n\t{} {} duplicate {}", duplicate_ids, verb, id));
                 }
 
@@ -101,7 +110,10 @@ impl fmt::Display for Error {
                 }
 
                 if *predate_applied > 0 {
-                    errs.push_str(&format!("\n\t{} pending occur before applied revisions", predate_applied));
+                    errs.push_str(&format!(
+                        "\n\t{} pending occur before applied revisions",
+                        predate_applied
+                    ));
                 }
 
                 write!(f, "Revisions review failed:{}", errs)

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,7 +62,7 @@ impl fmt::Display for Error {
             RevisionNameInvalid(filename) => {
                 write!(
                     f,
-                    "Invalid revision name `{}`: expected [timestamp].[name].sql",
+                    "Invalid revision name `{}`: expected `[id].[timestamp].[name].sql` eg. `001.1618370298.my-first-revision.sql`",
                     filename
                 )
             }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -12,8 +12,8 @@ CREATE SCHEMA $$schema$$
 const CREATE_TABLE: &str = "
 CREATE TABLE $$schema$$.$$table$$ (
     id          INT          PRIMARY KEY,
-    applied_on  TIMESTAMPTZ  NOT NULL,
     created_at  TIMESTAMPTZ  NOT NULL,
+    applied_on  TIMESTAMPTZ  NOT NULL,
     filename    TEXT         NOT NULL UNIQUE,
     name        TEXT         NOT NULL,
     checksum    TEXT         NOT NULL
@@ -40,7 +40,7 @@ SELECT
     filename,
     name
 FROM $$schema$$.$$table$$
-ORDER BY created_at ASC
+ORDER BY id ASC
 ";
 
 const INSERT_REVISION: &str = "
@@ -94,8 +94,8 @@ impl Executor {
             .map(|r| RevisionRecord {
                 id: r.get("id"),
                 applied_on: r.get("applied_on"),
-                checksum: r.get("checksum"),
                 created_at: r.get("created_at"),
+                checksum: r.get("checksum"),
                 filename: r.get("filename"),
                 name: r.get("name"),
             })

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -109,7 +109,8 @@ impl Executor {
             .replace("$$schema$$", &self.schema)
             .replace("$$table$$", &self.table);
 
-        let statements = revision.contents
+        let statements = revision
+            .contents
             .as_ref()
             .expect(format!("No content for {}", revision.filename).as_str());
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -51,7 +51,7 @@ INSERT INTO $$schema$$.$$table$$ (
     checksum,
     filename,
     name
-) VALUES (now(), $1, $2, $3, $4, $5)
+) VALUES (clock_timestamp(), $1, $2, $3, $4, $5)
 ";
 
 pub struct Executor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,11 @@ strategy = { type = "env-url-string", var-name = "JRNY_DATABASE_URL" }
 
 [table]
 # Specifies which schema and table `jrny` will use to track revision history.
+#
+# These can freely be changed for new projects. To update these for existing projects
+# with revisions already executed, you would need to first manually create the new table
+# and then copy all existing revision records from the old table into the new one prior
+# to running any commands with `jrny`. Otherwise, `jrny` will attempt to run all again.
 schema = "public"
 name = "jrny_revision"
 "#

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,10 @@ pub fn review(conf_path_name: Option<&str>) -> Result<()> {
     }
 
     info!("The journey thus far\n");
-    info!("  {:3}  {:43}{:25}{:25}", "Id", "Revision", "Created", "Applied");
+    info!(
+        "  {:3}  {:43}{:25}{:25}",
+        "Id", "Revision", "Created", "Applied"
+    );
 
     let format_local = |dt: DateTime<Utc>| DateTime::<Local>::from(dt)
         .format("%v %X")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,9 @@ pub fn review(conf_path_name: Option<&str>) -> Result<()> {
         }
     }
 
+    // TODO clean up? this isn't elegant
+    let mut previous_id = None;
+
     for (i, revision) in cmd.revisions.iter().enumerate() {
         let applied_on = match revision.applied_on {
             Some(a) => format_local(a),
@@ -114,6 +117,8 @@ pub fn review(conf_path_name: Option<&str>) -> Result<()> {
             Some("No corresponding file could not be found")
         } else if revision.applied_on.is_none() && (i as isize) < last_applied_index {
             Some("Later revisions have already been applied")
+        } else if previous_id == Some(revision.id) {
+            Some("Revision has duplicate id")
         } else {
             None
         };
@@ -135,6 +140,8 @@ pub fn review(conf_path_name: Option<&str>) -> Result<()> {
                 applied_on,
             ),
         }
+
+        previous_id = Some(revision.id);
     }
 
     Ok(())

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use crate::{Error, Result, CONF};
 
 /// A container for the various paths of interest for a project.
+#[derive(Debug)]
 pub struct ProjectPaths {
     pub conf: PathBuf,
     pub revisions: PathBuf,

--- a/src/revisions.rs
+++ b/src/revisions.rs
@@ -145,7 +145,8 @@ impl TryFrom<&str> for RevisionTitle {
             return Err(Error::RevisionNameInvalid(filename.to_string()));
         }
 
-        let id: i32 = parts[0].parse()
+        let id: i32 = parts[0]
+            .parse()
             .map_err(|_| Error::RevisionNameInvalid(filename.to_string()))?;
 
         let timestamp: i64 = parts[1]

--- a/src/revisions.rs
+++ b/src/revisions.rs
@@ -10,13 +10,17 @@ use crate::{Error, Result};
 /// Metadata and contents for a revision loaded from disk.
 #[derive(Debug)]
 pub struct RevisionFile {
+    /// The file id of the revision
     pub id: i32,
+    /// The hash of the contents
     pub checksum: String,
+    /// Contents of revision file, if present
     pub contents: String,
+    /// Moment the revision was created
     pub created_at: DateTime<Utc>,
-    /// The full name of the file, including timestamp and extension
+    /// The full name of the file, including id, timestamp, and extension
     pub filename: String,
-    /// The name of the file, excluding timestamp and extension
+    /// The name of the file, excluding id, timestamp, and extension
     pub name: String,
 }
 
@@ -61,9 +65,13 @@ impl TryFrom<&PathBuf> for RevisionFile {
 /// Metadata stored for a revision that has already been applied.
 #[derive(Debug)]
 pub struct RevisionRecord {
+    /// The database id of the revision
     pub id: i32,
+    /// Moment the revision was applied to the database
     pub applied_on: DateTime<Utc>,
+    /// The hash of the contents
     pub checksum: String,
+    /// Moment the revision was created
     pub created_at: DateTime<Utc>,
     /// The full name of the file, including timestamp and extension
     pub filename: String,
@@ -72,24 +80,31 @@ pub struct RevisionRecord {
 }
 
 /// Comprehensive metadata for a revision detected on disk or in the database.
-#[derive(Debug, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AnnotatedRevision {
+    /// The id of both the record and the revision file
     pub id: i32,
+    /// Moment the revision was applied to the database
     pub applied_on: Option<DateTime<Utc>>,
+    /// Checksum of the revision file on disk, if present
     pub checksum: Option<String>,
+    /// Whether or not checksums for file and record match, if both are present
     pub checksums_match: Option<bool>,
+    /// Contents of revision file, if present
     pub contents: Option<String>,
+    /// Moment the revision was created
     pub created_at: DateTime<Utc>,
-    /// The full name of the file, including timestamp and extension
+    /// The full name of the file, including id, timestamp, and extension
     pub filename: String,
-    /// The name of the file, excluding timestamp and extension
+    /// The name of the file, excluding id, timestamp, and extension
     pub name: String,
+    /// Whether or not the file for an applied revision is found on disk
     pub on_disk: bool,
 }
 
 impl Ord for AnnotatedRevision {
     fn cmp(&self, other: &Self) -> Ordering {
-        (&self.created_at, &self.filename).cmp(&(&other.created_at, &other.filename))
+        self.id.cmp(&other.id)
     }
 }
 
@@ -99,19 +114,14 @@ impl PartialOrd for AnnotatedRevision {
     }
 }
 
-impl PartialEq for AnnotatedRevision {
-    fn eq(&self, other: &Self) -> bool {
-        self.id         == other.id         &&
-        self.created_at == other.created_at &&
-        self.filename   == other.filename
-    }
-}
-
 /// Creation date and extension-less name extracted from a revision filename.
 #[derive(Debug, PartialEq)]
 struct RevisionTitle {
+    /// The numeric id extracted from the filename
     id: i32,
+    /// The file creation moment extracted from the filename
     created_at: DateTime<Utc>,
+    /// The remaining portion of the filename, excluding extension
     name: String,
 }
 

--- a/src/revisions.rs
+++ b/src/revisions.rs
@@ -180,8 +180,9 @@ mod tests {
     #[test]
     fn revision_title_parses_sql_filename() {
         assert_eq!(
-            RevisionTitle::try_from("1577836800.some-file.sql").unwrap(),
+            RevisionTitle::try_from("001.1577836800.some-file.sql").unwrap(),
             RevisionTitle {
+                id: 1,
                 created_at: Utc.ymd(2020, 1, 1).and_hms(0, 0, 0),
                 name: "some-file".to_string(),
             }
@@ -191,8 +192,9 @@ mod tests {
     #[test]
     fn revision_title_allows_multiple_periods() {
         assert_eq!(
-            RevisionTitle::try_from("1577836800.some.file.sql").unwrap(),
+            RevisionTitle::try_from("003.1577836800.some.file.sql").unwrap(),
             RevisionTitle {
+                id: 3,
                 created_at: Utc.ymd(2020, 1, 1).and_hms(0, 0, 0),
                 name: "some.file".to_string(),
             }
@@ -201,9 +203,9 @@ mod tests {
 
     #[test]
     fn revision_title_fails_non_sql() {
-        match RevisionTitle::try_from("1577836800.some-file.wat") {
+        match RevisionTitle::try_from("001.1577836800.some-file.wat") {
             Err(Error::RevisionNameInvalid(filename)) => {
-                assert_eq!(filename, "1577836800.some-file.wat".to_string());
+                assert_eq!(filename, "001.1577836800.some-file.wat".to_string());
             }
             _ => unreachable!(),
         }
@@ -211,15 +213,15 @@ mod tests {
 
     #[test]
     fn revision_title_fails_bad_timestamp() {
-        match RevisionTitle::try_from("a.some-file.sql") {
+        match RevisionTitle::try_from("001.asdf.some-file.sql") {
             Err(Error::RevisionTimestampInvalid(_, filename)) => {
-                assert_eq!(filename, "a.some-file.sql".to_string());
+                assert_eq!(filename, "001.asdf.some-file.sql".to_string());
             }
             result => panic!("received {:?}", result),
         }
-        match RevisionTitle::try_from("9999999999999999.some-file.sql") {
+        match RevisionTitle::try_from("001.9999999999999999.some-file.sql") {
             Err(Error::RevisionTimestampOutOfRange(filename)) => {
-                assert_eq!(filename, "9999999999999999.some-file.sql".to_string());
+                assert_eq!(filename, "001.9999999999999999.some-file.sql".to_string());
             }
             result => panic!("received {:?}", result),
         }


### PR DESCRIPTION
For https://github.com/kevlarr/jrny/issues/17

- [x] Use new revision name format `{id}.{timestamp}.{name}.sql`
- [x] Record ids in database w/o sequence
- [x] Enforce version cannot be used on previous projects with `{timestamp}.{name}.sql` format
- [x] Enforce unapplied revisions cannot be interleaved
- [x] Enforce unique ids prior to applying
- [x] Describe in README
- [x] tests
- [x] fmt