### PR TITLE
Add embark --through <id>

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,23 +404,8 @@ fn main() {
 
 ## Planned improvements, or "things that are missing"
 
-### Code cleanup
+See [enhancements](https://github.com/kevlarr/jrny/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement)
+for a running list of planned new features.
 
-Refactoring in Rust is fun - which is good, because there's a lot of room in this project
-for clearer patterns and modules, better code, etc.
-
-### Revision archiving
-
-Revisions are great, but we don't normally need revisions from 2 years ago sitting in the directory cluttering up the screen.
-
-This could take several forms but could possible involve concatenating all files into a single 'base' revision and resetting the revision
-table to mark that base as applied.
-
-### Revision 'bundling'
-
-Sometimes revisions are logically-related (ie. when developing a given feature) and it could make
-sense to group them together in a folder, just to help keep the files a little easier to browse.
-
-### Tests and automation
-
-No description necessary; there's barely any test coverage, and there's hardly any CI.
+More importantly, there is currently zero test coverage; fixing this is part of the
+[v2.0.0 milestone](https://github.com/kevlarr/jrny/issues?q=is%3Aopen+is%3Aissue+milestone%3Av2.0.0).

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ $ jrny embark
 No revisions to apply
 ```
 
-Additionally, instead of applying all pending revisions, you can apply all pending revisions
+Additionally, instead of applying all pending revisions, you can apply only those
 up through a specified id using `--through` or `-t`.
 
 For instance, given a review like:
@@ -395,9 +395,6 @@ fn main() {
     ")).unwrap();
 
     // Review the migrations
-    //
-    // This SHOULD return an error if any revisions fail review but currently does not.
-    // See: https://github.com/kevlarr/jrny/issues/31
     jrny::review(&cfg, &env).unwrap();
 
     // Run the migrations

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ determine if a file has been changed after being applied.
 
 #### Embark on the journey!
 
-To apply pending revisions, run `jrny embark`.
+To apply all pending revisions, run `jrny embark`.
 
 As with `jrny review`, applying revisions looks for default config & environment files in the current directory,
 but either can be overridden and, again, the database URL can be supplied directly.
@@ -299,7 +299,45 @@ Applying 1 revision(s)
 ```bash
 $ jrny embark
 
-No pending revisions
+No revisions to apply
+```
+
+Additionally, instead of applying all pending revisions, you can apply all pending revisions
+up through a specified id using `--through` or `-t`.
+
+For instance, given a review like:
+
+```bash
+$ jrny review
+
+The journey thus far:
+
+  [1] my-first-revision
+    Created on 30-Mar-2023 09:10:22
+    Applied on 30-Mar-2023 09:11:06
+
+  [2] another-revision
+    Created on 30-Mar-2023 09:10:32
+
+  [3] YET-another-revision
+    Created on 30-Mar-2023 09:27:58
+
+  [4] shocker-a-revision
+    Created on 19-Apr-2023 15:42:29
+
+  [5] surprise-another-revision
+    Created on 19-Apr-2023 15:42:36
+```
+
+If you only wanted to run up through `YET-another-revision` you would just pass the id `3`:
+
+```bash
+$ jrny embark --through 3
+
+Applying 2 revision(s), skipping 2
+
+  002.1680181832.another-revision.sql
+  008.1681952321.YET another revision.sql
 ```
 
 ## Library Usage

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -93,8 +93,7 @@ impl ReviewItem {
     }
 
     pub fn pending(&self) -> bool {
-        // Wow, clippy.. impressive
-        // if let FileOnly(_) = self.source { true } else { false }
+        // Eg. `if let FileOnly(_) = self.source { true } else { false }`
         matches!(self.source, FileOnly(_))
     }
 

--- a/src/commands/review.rs
+++ b/src/commands/review.rs
@@ -128,12 +128,12 @@ impl ReviewItem {
         // For extracting the equivalent record when iterating through files
         let mut records: HashMap<String, RevisionRecord> = records
             .into_iter()
-            .map(|record| (record.name.clone(), record))
+            .map(|record| (record.filename.clone(), record))
             .collect();
 
         for file in files {
             let mut problems = HashSet::new();
-            let item = match records.remove(&file.name) {
+            let item = match records.remove(&file.filename) {
                 Some(record) => {
                     if file.checksum != record.checksum {
                         problems.insert(RevisionProblem::FileChanged);

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,11 @@ struct Embark {
 
     #[command(flatten)]
     env: CliEnvironment,
+
+    #[arg(
+        help = "The id of the last revision to run, defaulting to the latest revision",
+    )]
+    through_id: Option<i32>,
 }
 
 #[derive(Parser, Debug)]
@@ -278,5 +283,5 @@ fn embark(cmd: Embark) -> JrnyResult<()> {
     let cfg: Config = cmd.cfg.try_into()?;
     let env = cmd.env.jrny_environment(&cfg)?;
 
-    jrny::embark(&cfg, &env)
+    jrny::embark(&cfg, &env, cmd.through_id)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ struct Review {
 #[command(
     about = "Reviews existing revisions for errors and applies pending revisions",
     long_about = "\
-Reviews existing revisions for errors. Applies pending revisions only if \
+Reviews existing revisions for errors and applies pending revisions if \
 no errors with existing revisions were found.",
 
 )]
@@ -116,8 +116,10 @@ struct Embark {
 
     #[arg(
         help = "The id of the last revision to run, defaulting to the latest revision",
+        short,
+        long,
     )]
-    through_id: Option<i32>,
+    through: Option<i32>,
 }
 
 #[derive(Parser, Debug)]
@@ -283,5 +285,5 @@ fn embark(cmd: Embark) -> JrnyResult<()> {
     let cfg: Config = cmd.cfg.try_into()?;
     let env = cmd.env.jrny_environment(&cfg)?;
 
-    jrny::embark(&cfg, &env, cmd.through_id)
+    jrny::embark(&cfg, &env, cmd.through)
 }

--- a/src/revisions.rs
+++ b/src/revisions.rs
@@ -23,16 +23,6 @@ impl TryFrom<&str> for RevisionTitle {
     fn try_from(filename: &str) -> std::result::Result<Self, Self::Error> {
         let parts: Vec<&str> = filename.split('.').collect();
 
-        // Regex would work too, but not sure it's worth the dependencies and
-        // binary size increase.
-        //
-        // TODO: maybe just use nightly? Eg.
-        //
-        //     let (timestamp, name) = match parts.as_slice() {
-        //         [timestamp, .. name, "sql"] => (timestamp, name.join(".")),
-        //         _ => return Err(err()),
-        //     };
-
         if parts.len() < 4 || parts.last() != Some(&"sql") {
             return Err(Error::RevisionNameInvalid(filename.to_string()));
         }
@@ -45,7 +35,7 @@ impl TryFrom<&str> for RevisionTitle {
             .parse()
             .map_err(|e| Error::RevisionTimestampInvalid(e, filename.to_string()))?;
 
-        // Utc.timestamp can panic, hence `timestamp_opt`
+        // `Utc.timestamp` can panic, hence `timestamp_opt`
         let created_at = Utc
             .timestamp_opt(timestamp, 0)
             .single()


### PR DESCRIPTION
- Address https://github.com/kevlarr/jrny/issues/41
- Fixes bug where revision file<->record mapping was [based on descriptive name portion](https://github.com/kevlarr/jrny/commit/60aa1500224b3102310453eb2ef9d03aefb206ab#diff-e4b8260dac2f50ac96f9d5c26e9f8ce6aed208f9d902f73216890595c263e19fR132) and not whole filename
